### PR TITLE
function pointers for signal-slot connections in effects system

### DIFF
--- a/src/effects/effectbuttonparameterslot.cpp
+++ b/src/effects/effectbuttonparameterslot.cpp
@@ -22,8 +22,8 @@ EffectButtonParameterSlot::EffectButtonParameterSlot(const QString& group,
     m_pControlType = new ControlObject(
             ConfigKey(m_group, itemPrefix + QString("_type")));
 
-    connect(m_pControlValue, SIGNAL(valueChanged(double)),
-            this, SLOT(slotValueChanged(double)));
+    connect(m_pControlValue, &ControlObject::valueChanged,
+            this, &EffectButtonParameterSlot::slotValueChanged);
 
     // Read-only controls.
     m_pControlType->setReadOnly();
@@ -77,8 +77,8 @@ void EffectButtonParameterSlot::loadParameter(EffectParameter* pEffectParameter)
         // Default loaded parameters to loaded and unlinked
         m_pControlLoaded->forceSet(1.0);
 
-        connect(m_pEffectParameter, SIGNAL(valueChanged(double)),
-                this, SLOT(slotParameterValueChanged(double)));
+        connect(m_pEffectParameter, &EffectParameter::valueChanged,
+                this, &EffectButtonParameterSlot::slotParameterValueChanged);
     }
 
     emit(updated());

--- a/src/effects/effectknobparameterslot.cpp
+++ b/src/effects/effectknobparameterslot.cpp
@@ -18,8 +18,8 @@ EffectKnobParameterSlot::EffectKnobParameterSlot(const QString& group, const uns
 
     m_pControlValue = new ControlEffectKnob(
             ConfigKey(m_group, itemPrefix));
-    connect(m_pControlValue, SIGNAL(valueChanged(double)),
-            this, SLOT(slotValueChanged(double)));
+    connect(m_pControlValue, &ControlObject::valueChanged,
+            this, &EffectKnobParameterSlot::slotValueChanged);
 
     m_pControlLoaded = new ControlObject(
             ConfigKey(m_group, itemPrefix + QString("_loaded")));
@@ -40,8 +40,8 @@ EffectKnobParameterSlot::EffectKnobParameterSlot(const QString& group, const uns
     m_pControlLinkInverse = new ControlPushButton(
             ConfigKey(m_group, itemPrefix + QString("_link_inverse")));
     m_pControlLinkInverse->setButtonMode(ControlPushButton::TOGGLE);
-    connect(m_pControlLinkInverse, SIGNAL(valueChanged(double)),
-            this, SLOT(slotLinkInverseChanged(double)));
+    connect(m_pControlLinkInverse, &ControlObject::valueChanged,
+            this, &EffectKnobParameterSlot::slotLinkInverseChanged);
 
     m_pMetaknobSoftTakeover = new SoftTakeover();
 
@@ -97,8 +97,8 @@ void EffectKnobParameterSlot::loadParameter(EffectParameter* pEffectParameter) {
         m_pControlLinkInverse->set(
             static_cast<double>(m_pManifestParameter->defaultLinkInversion()));
 
-        connect(m_pEffectParameter, SIGNAL(valueChanged(double)),
-                this, SLOT(slotParameterValueChanged(double)));
+        connect(m_pEffectParameter, &EffectParameter::valueChanged,
+                this, &EffectKnobParameterSlot::slotParameterValueChanged);
     }
 
     emit(updated());

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -49,25 +49,25 @@ EffectSlot::EffectSlot(const QString& group,
     // at the beginning of a set.
     m_pControlEnabled = new ControlPushButton(ConfigKey(m_group, "enabled"));
     m_pControlEnabled->setButtonMode(ControlPushButton::POWERWINDOW);
-    connect(m_pControlEnabled, SIGNAL(valueChanged(double)),
-            this, SLOT(updateEngineState()));
+    connect(m_pControlEnabled, &ControlObject::valueChanged,
+            this, &EffectSlot::updateEngineState);
 
     m_pControlNextEffect = new ControlPushButton(ConfigKey(m_group, "next_effect"));
-    connect(m_pControlNextEffect, SIGNAL(valueChanged(double)),
-            this, SLOT(slotNextEffect(double)));
+    connect(m_pControlNextEffect, &ControlObject::valueChanged,
+            this, &EffectSlot::slotNextEffect);
 
     m_pControlPrevEffect = new ControlPushButton(ConfigKey(m_group, "prev_effect"));
-    connect(m_pControlPrevEffect, SIGNAL(valueChanged(double)),
-            this, SLOT(slotPrevEffect(double)));
+    connect(m_pControlPrevEffect, &ControlObject::valueChanged,
+            this, &EffectSlot::slotPrevEffect);
 
     // Ignoring no-ops is important since this is for +/- tickers.
     m_pControlEffectSelector = new ControlEncoder(ConfigKey(m_group, "effect_selector"), false);
-    connect(m_pControlEffectSelector, SIGNAL(valueChanged(double)),
-            this, SLOT(slotEffectSelector(double)));
+    connect(m_pControlEffectSelector, &ControlObject::valueChanged,
+            this, &EffectSlot::slotEffectSelector);
 
     m_pControlClear = new ControlPushButton(ConfigKey(m_group, "clear"));
-    connect(m_pControlClear, SIGNAL(valueChanged(double)),
-            this, SLOT(slotClear(double)));
+    connect(m_pControlClear, &ControlObject::valueChanged,
+            this, &EffectSlot::slotClear);
 
     for (unsigned int i = 0; i < kDefaultMaxParameters; ++i) {
         addEffectParameterSlot(EffectManifestParameter::ParameterType::KNOB);
@@ -75,8 +75,11 @@ EffectSlot::EffectSlot(const QString& group,
     }
 
     m_pControlMetaParameter = new ControlPotmeter(ConfigKey(m_group, "meta"), 0.0, 1.0);
-    connect(m_pControlMetaParameter, SIGNAL(valueChanged(double)),
-            this, SLOT(slotEffectMetaParameter(double)));
+    // QObject::connect cannot connect to slots with optional parameters using function
+    // pointer syntax if the slot has more parameters than the signal, so use a lambda
+    // to hack around this limitation.
+    connect(m_pControlMetaParameter, &ControlObject::valueChanged,
+            this, [=](double value){slotEffectMetaParameter(value);} );
     m_pControlMetaParameter->set(0.0);
     m_pControlMetaParameter->setDefaultValue(0.0);
 


### PR DESCRIPTION
Qt 5 allows using function pointers for signal-slot connections instead of the hacky old SIGNAL and SLOT macros. The new syntax allows compile time type checking and IDEs can make sense of it. No more typos breaking connections!